### PR TITLE
az-cvm-vtpm: hyphenize tees in serialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,10 @@ pub use tee::snp::{Error as SnpDecodeError, SnpAttestation};
 #[derive(Serialize, Clone, Copy, Deserialize, Debug, Eq, Hash, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Tee {
+    // Azure CVMs with vTPM attestation
+    #[serde(rename = "az-snp-vtpm")]
     AzSnpVtpm,
+    #[serde(rename = "az-tdx-vtpm")]
     AzTdxVtpm,
     Nvidia,
     Sev,


### PR DESCRIPTION
we use strings like `az-snp-vtpm` in all the stack, but for policies tee's are defined as `azsnpvtpm` which has been a source of confusion. If we can merge this, I would update trustee and the default policies to reflect this.