### PR TITLE
lib: Serialize TeePubKey to EAR map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,11 @@ license = "Apache-2.0"
 [features]
 default = [ "std" ]
 alloc = ["base64/alloc",  "serde/alloc", "serde_json/alloc" ]
-std = ["base64/std", "serde/std", "serde_json/std", "thiserror/std"]
+std = ["base64/std", "serde/std", "serde_json/std", "thiserror/std", "dep:ear"]
 
 [dependencies]
 base64 = { version = "0.22.1", default-features = false }
+ear = { version = "0.4.0", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
 sha2 = "0.10"


### PR DESCRIPTION
Often, TeePubKeys are serialized to JSON format. The rust ear library provides equivalent types for representing data, including an EAR map. Allow for serialization of a TeePubKey to an EAR map and ensure that this map can be deserialized as a JSON object in return.

@Xynnn007 this fixes the producer problem mentioned [here](https://github.com/confidential-containers/trustee/pull/959#pullrequestreview-3226882770).